### PR TITLE
Add dot exporting

### DIFF
--- a/example.py
+++ b/example.py
@@ -60,3 +60,14 @@ st_fig_path = create_path('out/falls_staged_tree', True, 'pdf')
 falls_et.create_figure(et_fig_path)
 falls_st.calculate_AHC_transitions(colour_list=colours)
 falls_st.create_figure(st_fig_path)
+
+# get the dot graph 
+falls_st_dot = falls_st.dot_graph
+# modify nodes and edges
+falls_st_dot.get_edge("s1", "s5")[0].set_style("dotted")
+falls_st_dot.get_edge("s1", "s6")[0].set_style("dotted")
+falls_st_dot.get_node("s1")[0].set_shape("square")
+# save as a pdf
+falls_st_dot.write("out/falls_modified_staged_tree.pdf", format="pdf") 
+# or save as a dot
+falls_st_dot.write("out/falls_modified_staged_tree.dot", format="dot") 

--- a/src/cegpy/graphs/ceg.py
+++ b/src/cegpy/graphs/ceg.py
@@ -269,13 +269,11 @@ class ChainEventGraph(nx.MultiDiGraph):
         relabel_nodes([self.root_node])
         self.__update_path_list()
 
-    def create_figure(self, filename):
-        """
-        Draws the chain event graph representation of the stage tree,
-        and saves it to "<filename>.filetype". Supports any filetype that
-        graphviz supports. e.g: "event_tree.png" or "event_tree.svg" etc.
-        """
-        filename, filetype = Util.generate_filename_and_mkdir(filename)
+    @property
+    def dot_graph(self):
+        return self._generate_dot_graph()
+
+    def _generate_dot_graph(self):
         graph = pdp.Dot(graph_type='digraph', rankdir='LR')
         edge_probabilities = list(
             self.edges(data='probability', default=1, keys=True)
@@ -308,7 +306,16 @@ class ChainEventGraph(nx.MultiDiGraph):
                     fillcolor=fill_colour
                 )
             )
+        return graph
 
+    def create_figure(self, filename):
+        """
+        Draws the chain event graph representation of the stage tree,
+        and saves it to "<filename>.filetype". Supports any filetype that
+        graphviz supports. e.g: "event_tree.png" or "event_tree.svg" etc.
+        """
+        filename, filetype = Util.generate_filename_and_mkdir(filename)
+        graph = self.dot_graph
         graph.write(str(filename), format=filetype)
 
         if get_ipython() is None:

--- a/src/cegpy/trees/event.py
+++ b/src/cegpy/trees/event.py
@@ -140,9 +140,6 @@ class EventTree(nx.MultiDiGraph):
         self.__construct_event_tree()
         logger.info('Initialisation complete!')
 
-        # creat the dot graph representation
-        self._dot_graph = None
-
     @property
     def root(self) -> str:
         """Root node of the event tree.
@@ -309,7 +306,7 @@ class EventTree(nx.MultiDiGraph):
             return None
         else:
             logger.info("--- Exporting graph to notebook ---")
-            return Image(self.graph.create_png())
+            return Image(graph.create_png())
 
     def __create_unsorted_paths_dict(self) -> defaultdict:
         """Creates and populates a dictionary of all paths provided in the dataframe,

--- a/src/cegpy/trees/event.py
+++ b/src/cegpy/trees/event.py
@@ -140,6 +140,9 @@ class EventTree(nx.MultiDiGraph):
         self.__construct_event_tree()
         logger.info('Initialisation complete!')
 
+        # creat the dot graph representation
+        self._dot_graph = None
+
     @property
     def root(self) -> str:
         """Root node of the event tree.
@@ -256,7 +259,11 @@ class EventTree(nx.MultiDiGraph):
 
         return self._catagories_per_variable
 
-    def _generate_pdp_graph(self):
+    @property
+    def dot_graph(self):
+        return self._generate_dot_graph()
+
+    def _generate_dot_graph(self):
         node_list = list(self)
         graph = pdp.Dot(graph_type='digraph', rankdir='LR')
         for edge, count in self.edge_counts.items():
@@ -294,7 +301,7 @@ class EventTree(nx.MultiDiGraph):
         """
         filename, filetype = Util.generate_filename_and_mkdir(filename)
         logger.info("--- generating graph ---")
-        graph = self._generate_pdp_graph()
+        graph = self.dot_graph
         logger.info("--- writing " + filetype + " file ---")
         graph.write(str(filename), format=filetype)
 
@@ -302,7 +309,7 @@ class EventTree(nx.MultiDiGraph):
             return None
         else:
             logger.info("--- Exporting graph to notebook ---")
-            return Image(graph.create_png())
+            return Image(self.graph.create_png())
 
     def __create_unsorted_paths_dict(self) -> defaultdict:
         """Creates and populates a dictionary of all paths provided in the dataframe,

--- a/src/cegpy/trees/staged.py
+++ b/src/cegpy/trees/staged.py
@@ -511,7 +511,7 @@ class StagedTree(EventTree):
             self.ahc_output
             filename, filetype = Util.generate_filename_and_mkdir(filename)
             logger.info("--- generating graph ---")
-            graph = self._generate_pdp_graph()
+            graph = self.dot_graph
             logger.info("--- writing " + filetype + " file ---")
             graph.write(str(filename), format=filetype)
 


### PR DESCRIPTION
Proposal to solving #27 

I added the possibility for the user to directly work with the graph object generated with PyDotPlus. `example.py` contains a a working example of how one can modify some edges / nodes after the graph is created and how it can be saved to any format file supported by Graphviz, such as .dot or .pdf.