### PR TITLE
Add var_order to the StagedTree constructor

### DIFF
--- a/src/cegpy/trees/staged.py
+++ b/src/cegpy/trees/staged.py
@@ -23,6 +23,7 @@ class StagedTree(EventTree):
             hyperstage=None,
             sampling_zero_paths=None,
             incoming_graph_data=None,
+            var_order=None,
             **attr) -> None:
 
         # Call event tree init to generate event tree
@@ -30,6 +31,7 @@ class StagedTree(EventTree):
             dataframe,
             sampling_zero_paths,
             incoming_graph_data,
+            var_order,
             **attr
         )
 


### PR DESCRIPTION
This is a very small change regarding #22. The argument `var_order` was missing from the StagedTree constructor. It still worked due to the **args argument, but I think that for clarity it can be listed separately. (That way `var_order` may be displayed explicitly in the parameter hints in most IDEs, which I find helpful).