### PR TITLE
Python notebook - displaying graphs

### DIFF
--- a/src/cegpy/graphs/ceg.py
+++ b/src/cegpy/graphs/ceg.py
@@ -253,7 +253,7 @@ class ChainEventGraph(nx.MultiDiGraph):
         )
 
         for (u, v, k, p) in edge_probabilities:
-            full_label = "{}\n{:.2f}".format(k, p)
+            full_label = f"{k}\n{float(p):.2f}"
             graph.add_edge(
                 pdp.Edge(
                     src=u,
@@ -281,20 +281,27 @@ class ChainEventGraph(nx.MultiDiGraph):
             )
         return graph
 
-    def create_figure(self, filename):
+    def create_figure(self, filename=None):
         """
         Draws the chain event graph representation of the stage tree,
         and saves it to "<filename>.filetype". Supports any filetype that
         graphviz supports. e.g: "event_tree.png" or "event_tree.svg" etc.
         """
-        filename, filetype = Util.generate_filename_and_mkdir(filename)
         graph = self.dot_graph
-        graph.write(str(filename), format=filetype)
-
-        if get_ipython() is None:
-            return None
+        if filename is None:
+            logger.warn("No filename. Figure not saved.")
         else:
-            return Image(graph.create_png())
+            filename, filetype = Util.generate_filename_and_mkdir(filename)
+            logger.info("--- generating graph ---")
+            logger.info("--- writing " + filetype + " file ---")
+            graph.write(str(filename), format=filetype)
+            graph_image = None
+    
+        if get_ipython is not None:
+            logger.info("--- Exporting graph to notebook ---")
+            graph_image = Image(graph.create_png())
+
+        return graph_image
 
     def _update_probabilities(self):
         count_total_lbl = 'count_total'

--- a/src/cegpy/trees/event.py
+++ b/src/cegpy/trees/event.py
@@ -357,22 +357,28 @@ class EventTree(nx.MultiDiGraph):
                     fillcolor=fill_node_colour))
         return graph
 
-    def create_figure(self, filename):
+    def _create_figure(self, graph, filename):
         """Draws the event tree for the process described by the dataset,
         and saves it to "<filename>.filetype". Supports any filetype that
         graphviz supports. e.g: "event_tree.png" or "event_tree.svg" etc.
         """
-        filename, filetype = Util.generate_filename_and_mkdir(filename)
-        logger.info("--- generating graph ---")
-        graph = self.dot_event_graph
-        logger.info("--- writing " + filetype + " file ---")
-        graph.write(str(filename), format=filetype)
-
-        if get_ipython() is None:
-            return None
+        if filename is None:
+            logger.warn("No filename. Figure not saved.")
         else:
+            filename, filetype = Util.generate_filename_and_mkdir(filename)
+            logger.info("--- generating graph ---")
+            logger.info("--- writing " + filetype + " file ---")
+            graph.write(str(filename), format=filetype)
+            graph_image = None
+    
+        if get_ipython is not None:
             logger.info("--- Exporting graph to notebook ---")
-            return Image(graph.create_png())
+            graph_image = Image(graph.create_png())
+
+        return graph_image
+
+    def create_figure(self, filename=None):
+        return self._create_figure(self.dot_event_graph, filename)
 
     def __create_unsorted_paths_dict(self) -> defaultdict:
         """Creates and populates a dictionary of all paths provided in the dataframe,

--- a/src/cegpy/trees/staged.py
+++ b/src/cegpy/trees/staged.py
@@ -608,7 +608,7 @@ class StagedTree(EventTree):
     def dot_staged_graph(self):
         return self._generate_dot_graph()
 
-    def create_figure(self, filename, staged=True):
+    def create_figure(self, filename=None, staged=True):
         """Draws the coloured staged tree for the process described by
         the dataset, and saves it to "<filename>.filetype". Supports
         any filetype that graphviz supports. e.g: "event_tree.png" or
@@ -616,28 +616,19 @@ class StagedTree(EventTree):
         """
         if staged:
             try:
-                self.ahc_output
-                filename, filetype = Util.generate_filename_and_mkdir(filename)
-                logger.info("--- generating graph ---")
+                ahc = self._ahc_output
                 graph = self.dot_staged_graph
-                logger.info("--- writing " + filetype + " file ---")
-                graph.write(str(filename), format=filetype)
-
-                if get_ipython() is None:
-                    return None
-                else:
-                    logger.info("--- Exporting graph to notebook ---")
-                    return Image(graph.create_png())
+                graph_image = super()._create_figure(graph, filename)
 
             except AttributeError:
                 logger.error(
                     "----- PLEASE RUN AHC ALGORITHM before trying to" +
-                    " export graph -----"
+                    " export a staged tree graph -----"
                 )
-                return None
+                graph_image = None
         else:
-            super().create_figure(filename)
-
+            graph_image = super().create_figure(filename)
+        return graph_image
 
 def _calculate_and_apply_mean_posterior_probs(
     staged: StagedTree, merged_situations: List, posteriors: List

--- a/tests/test_staged.py
+++ b/tests/test_staged.py
@@ -728,10 +728,9 @@ class TestStagedTrees():
         with pytest.raises(IndexError):
             self.fall_st.calculate_AHC_transitions(colour_list=colours)
 
-    def test_run_AHC_before_figure(self) -> None:
-        with pytest.raises(Exception):
-            self.med_st.create_figure()
-
+    def test_run_AHC_before_figure(self, caplog) -> None:
+        self.med_st.create_figure()
+        assert 'PLEASE RUN AHC' in caplog.text
 
 class TestChangingDataFrame():
     def setup(self):


### PR DESCRIPTION
Makes filename optional and enables displaying the graphs in Jupyter notebooks without saving to a file.

Fixes a related unit test.

Resolves #72 