### PR TITLE
Upversioned dependencies and fixed testing strategy

### DIFF
--- a/.github/workflows/python-app.yaml
+++ b/.github/workflows/python-app.yaml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Install dependencies

--- a/.github/workflows/python-app.yaml
+++ b/.github/workflows/python-app.yaml
@@ -24,7 +24,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install wheel
-        pip install flake8 pytest pandas pydotplus IPython colorutils networkx
+        pip install flake8 pytest pandas pydotplus IPython colorutils
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with pytest
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ cegpy-binder
 docs/_build/*
 .mypy
 build
+.venv
+venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ scipy>=1.7.0
 colorutils>=0.3.0
 xlsxwriter>=3.0.0
 tox>=4.2.8
+networkx>=3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ scipy>=1.7.0
 colorutils>=0.3.0
 xlsxwriter>=3.0.0
 tox>=4.2.8
-networkx>=3.3
+networkx>=3.2.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,14 +18,14 @@ classifiers =
 package_dir =
     = src
 packages = find:
-python_requires = >=3.6
+python_requires= >=3.9
 install_requires =
     pandas >=1.3.0
     pydotplus >=2.0.2
     ipython >=7.25.0
     scipy >=1.7.0
     colorutils >=0.3.0
-    networkx >=2.6.3
+    networkx >=3.2.1
 
 license_files=
     LICENSE

--- a/src/tests/test_ceg.py
+++ b/src/tests/test_ceg.py
@@ -2,13 +2,11 @@
 # pylint: disable=protected-access
 import re
 from pathlib import Path
-from typing import Dict, List, Mapping, Tuple
+from typing import Dict, Mapping
 import unittest
 from unittest.mock import Mock, patch
 import networkx as nx
 import pandas as pd
-import pytest
-import pytest_mock
 from cegpy import StagedTree, ChainEventGraph
 from cegpy.graphs._ceg import (
     CegAlreadyGenerated,
@@ -16,14 +14,14 @@ from cegpy.graphs._ceg import (
 )
 
 
-class TestMockedCEGMethods:
+class TestMockedCEGMethods(unittest.TestCase):
     """Tests that Mock functions in ChainEventGraph"""
 
     node_prefix = "w"
     sink_suffix = "&infin;"
     staged: StagedTree
 
-    def setup(self):
+    def setUp(self):
         """Test setup"""
         df_path = (
             Path(__file__)
@@ -34,12 +32,12 @@ class TestMockedCEGMethods:
         self.staged = StagedTree(dataframe=pd.read_excel(df_path))
         self.staged.calculate_AHC_transitions()
 
-    def test_generate_argument(self, mocker: pytest_mock.MockerFixture):
+    @patch("cegpy.graphs._ceg.ChainEventGraph.generate", autospec=True)
+    def test_generate_argument(self, generate_mock: Mock):
         """When ChainEventGraph called with generate, the .generate()
         method is called."""
-        mocker.patch("cegpy.graphs._ceg.ChainEventGraph.generate")
-        ceg = ChainEventGraph(self.staged, generate=True)
-        ceg.generate.assert_called_once()  # pylint: disable=no-member
+        ChainEventGraph(self.staged, generate=True)
+        generate_mock.assert_called_once()  # pylint: disable=no-member
 
 
 class TestUnitCEG(unittest.TestCase):

--- a/src/tests/test_ceg_reducer.py
+++ b/src/tests/test_ceg_reducer.py
@@ -443,8 +443,8 @@ class TestCEGReducer(unittest.TestCase):
             assert str(node) in str_rep
 
 
-class TestReducedCEGTwo(object):
-    def setup(self):
+class TestReducedCEGTwo(unittest.TestCase):
+    def setUp(self):
         G = nx.MultiDiGraph()
         self.init_nodes = ["w0", "w1", "w2", "w3", "w4", "w5", "w6", "w_infinity"]
         self.init_edges = [

--- a/src/tests/test_event.py
+++ b/src/tests/test_event.py
@@ -38,8 +38,8 @@ class TestEventTreeAPI(unittest.TestCase):
         )
 
 
-class TestEventTree:
-    def setup(self):
+class TestEventTree(unittest.TestCase):
+    def setUp(self):
         df_path = (
             Path(__file__)
             .resolve()
@@ -148,8 +148,8 @@ class TestEventTree:
         assert event_node_colours[0] == "lightgrey"
 
 
-class TestIntegration:
-    def setup(self):
+class TestIntegration(unittest.TestCase):
+    def setUp(self):
         # stratified dataset
         med_df_path = (
             Path(__file__)
@@ -198,8 +198,8 @@ def check_list_contains_strings(str_list) -> bool:
         assert isinstance(elem, str)
 
 
-class TestUsecase:
-    def setup(self):
+class TestUsecase(unittest.TestCase):
+    def setUp(self):
         # stratified dataset
         med_df_path = (
             Path(__file__)
@@ -232,7 +232,6 @@ class TestUsecase:
 
 
 class TestChangingDataFrame:
-
     @pytest.fixture
     def med_df(self):
         # stratified dataset
@@ -247,9 +246,7 @@ class TestChangingDataFrame:
     @pytest.fixture
     def med_et(self, med_df):
         med_s_z_paths = None
-        med_et = EventTree(
-            dataframe=med_df, sampling_zero_paths=med_s_z_paths
-        )
+        med_et = EventTree(dataframe=med_df, sampling_zero_paths=med_s_z_paths)
         return med_et
 
     @pytest.fixture
@@ -263,10 +260,7 @@ class TestChangingDataFrame:
     @pytest.fixture
     def fall_et(self, fall_df):
         self.fall_s_z_paths = None
-        return EventTree(
-            dataframe=fall_df, sampling_zero_paths=self.fall_s_z_paths
-        )
-
+        return EventTree(dataframe=fall_df, sampling_zero_paths=self.fall_s_z_paths)
 
     def test_add_empty_column(self, fall_et, med_df, med_et, fall_df) -> None:
         # adding empty column
@@ -325,8 +319,8 @@ class TestChangingDataFrame:
         assert len(fall_add_same_et.leaves) == len(fall_et.leaves)
 
 
-class TestMissingLabels:
-    def setup(self):
+class TestMissingLabels(unittest.TestCase):
+    def setUp(self):
         array = [
             np.array(["1", "NotANum", "Recover"]),
             np.array(["1", "Trt1", "NotANum"]),
@@ -538,8 +532,8 @@ class TestMissingLabels:
         assert df_et.dataframe.equals(expected_df) is True
 
 
-class TestVariablesFiltered:
-    def setup(self):
+class TestVariablesFiltered(unittest.TestCase):
+    def setUp(self):
         array = [
             np.array(["1", "NotANum", "Recover"]),
             np.array(["1", "Trt1", "NotANum"]),
@@ -548,7 +542,7 @@ class TestVariablesFiltered:
             np.array(["1", "Trt1", "Recover"]),
             np.array(["1", "Trt2", "Recover"]),
             np.array(["1", "Trt2", "Dont Recover"]),
-            np.array(["1", np.NaN, "Dont Recover"]),
+            np.array(["1", np.nan, "Dont Recover"]),
         ]
 
         self.df = pd.DataFrame(array)
@@ -575,8 +569,8 @@ class TestVariablesFiltered:
         assert df_et.categories_per_variable == expected_categories
 
 
-class TestStageColours:
-    def setup(self):
+class TestStageColours(unittest.TestCase):
+    def setUp(self):
         array = [
             np.array(["1", "NotANum", "Recover"]),
             np.array(["1", "Trt1", "NotANum"]),
@@ -585,7 +579,7 @@ class TestStageColours:
             np.array(["1", "Trt1", "Recover"]),
             np.array(["1", "Trt2", "Recover"]),
             np.array(["1", "Trt2", "Dont Recover"]),
-            np.array(["1", np.NaN, "Dont Recover"]),
+            np.array(["1", np.nan, "Dont Recover"]),
         ]
 
         self.df = pd.DataFrame(array)

--- a/src/tests/test_event.py
+++ b/src/tests/test_event.py
@@ -232,84 +232,97 @@ class TestUsecase:
 
 
 class TestChangingDataFrame:
-    def setup(self):
+
+    @pytest.fixture
+    def med_df(self):
         # stratified dataset
         med_df_path = (
             Path(__file__)
             .resolve()
             .parent.parent.joinpath("../data/medical_dm_modified.xlsx")
         )
-        self.med_s_z_paths = None
-        self.med_df = pd.read_excel(med_df_path)
-        self.med_et = EventTree(
-            dataframe=self.med_df, sampling_zero_paths=self.med_s_z_paths
-        )
 
+        return pd.read_excel(med_df_path)
+
+    @pytest.fixture
+    def med_et(self, med_df):
+        med_s_z_paths = None
+        med_et = EventTree(
+            dataframe=med_df, sampling_zero_paths=med_s_z_paths
+        )
+        return med_et
+
+    @pytest.fixture
+    def fall_df(self):
         # non-stratified dataset
         fall_df_path = (
             Path(__file__).resolve().parent.parent.joinpath("../data/Falls_Data.xlsx")
         )
+        return pd.read_excel(fall_df_path)
+
+    @pytest.fixture
+    def fall_et(self, fall_df):
         self.fall_s_z_paths = None
-        self.fall_df = pd.read_excel(fall_df_path)
-        self.fall_et = EventTree(
-            dataframe=self.fall_df, sampling_zero_paths=self.fall_s_z_paths
+        return EventTree(
+            dataframe=fall_df, sampling_zero_paths=self.fall_s_z_paths
         )
 
-    def test_add_empty_column(self) -> None:
+
+    def test_add_empty_column(self, fall_et, med_df, med_et, fall_df) -> None:
         # adding empty column
-        med_empty_column_df = self.med_df
+        med_empty_column_df = med_df
         med_empty_column_df["extra"] = ""
         med_empty_column_et = EventTree(dataframe=med_empty_column_df)
-        assert med_empty_column_et.adj == self.med_et.adj
+        assert med_empty_column_et.adj == med_et.adj
 
-        fall_empty_column_df = self.fall_df
+        fall_empty_column_df = fall_df
         fall_empty_column_df["extra"] = ""
         fall_empty_column_et = EventTree(dataframe=fall_empty_column_df)
-        assert fall_empty_column_et.adj == self.fall_et.adj
+        assert fall_empty_column_et.adj == fall_et.adj
 
-    def test_add_NA_column(self) -> None:
+    def test_add_NA_column(self, fall_et, med_df, med_et, fall_df) -> None:
         # adding NA column
-        med_add_NA_df = self.med_df
+        med_add_NA_df = med_df
         med_add_NA_df["extra"] = np.nan
         med_add_NA_et = EventTree(dataframe=med_add_NA_df)
-        assert med_add_NA_et.adj == self.med_et.adj
+        assert med_add_NA_et.adj == med_et.adj
 
-        fall_add_NA_df = self.fall_df
+        fall_add_NA_df = fall_df
         fall_add_NA_df["extra"] = np.nan
         fall_add_NA_et = EventTree(dataframe=fall_add_NA_df)
-        assert fall_add_NA_et.adj == self.fall_et.adj
+        assert fall_add_NA_et.adj == fall_et.adj
 
-    def test_add_same_column(self) -> None:
+    def test_add_same_column(self, fall_et, med_df, med_et, fall_df) -> None:
         # adding column with no more information
-        med_add_same_df = self.med_df
+        med_add_same_df = med_df
         med_add_same_df["extra"] = "same for all"
         med_add_same_et = EventTree(dataframe=med_add_same_df)
-        assert len(med_add_same_et.leaves) == len(self.med_et.leaves)
+        assert len(med_add_same_et.leaves) == len(med_et.leaves)
 
-        fall_add_same_df = self.fall_df
+        fall_add_same_df = fall_df
         fall_add_same_df["extra"] = "same for all"
         fall_add_same_et = EventTree(dataframe=fall_add_same_df)
-        assert len(fall_add_same_et.leaves) == len(self.fall_et.leaves)
+        assert len(fall_add_same_et.leaves) == len(fall_et.leaves)
 
-    def test_add_same_column_int(self) -> None:
+    def test_add_same_column_int(self, fall_et, med_df, med_et, fall_df) -> None:
         # adding column with no more information
-        med_add_same_df = self.med_df
+        med_add_same_df = med_df
         med_add_same_df["extra"] = 1
         med_add_same_et = EventTree(dataframe=med_add_same_df)
         try:
             med_add_same_et.create_figure("et_fig_path.pdf")
         except InvocationException:
             pass
-        assert len(med_add_same_et.leaves) == len(self.med_et.leaves)
+        assert len(med_add_same_et.leaves) == len(med_et.leaves)
 
-        fall_add_same_df = self.fall_df
+        fall_add_same_df = fall_df
         fall_add_same_df["extra"] = 1
         fall_add_same_et = EventTree(dataframe=fall_add_same_df)
         try:
             fall_add_same_et.create_figure("et_fig_path.pdf")
         except InvocationException:
             pass
-        assert len(fall_add_same_et.leaves) == len(self.fall_et.leaves)
+        assert len(fall_add_same_et.leaves) == len(fall_et.leaves)
 
 
 class TestMissingLabels:

--- a/src/tests/test_staged.py
+++ b/src/tests/test_staged.py
@@ -16,37 +16,51 @@ from cegpy.trees._staged import _calculate_mean_posterior_probs
 class TestLogging:
     """Tests logging in stagedtree"""
 
-    def setup(self):
-        """Test setup"""
-        # pylint: disable=attribute-defined-outside-init
-        # stratified dataset
+    @pytest.fixture
+    def med_st(self):
         med_df_path = (
             Path(__file__)
             .resolve()
             .parent.parent.joinpath("../data/medical_dm_modified.xlsx")
         )
-        self.med_s_z_paths = None
-        self.med_df = pd.read_excel(med_df_path)
-        self.med_st = StagedTree(
-            dataframe=self.med_df, sampling_zero_paths=self.med_s_z_paths
+        med_s_z_paths = None
+        med_df = pd.read_excel(med_df_path)
+        med_st = StagedTree(
+            dataframe=med_df, sampling_zero_paths=med_s_z_paths
         )
+        return med_st
 
-        # non-stratified dataset
-        fall_df_path = (
-            Path(__file__).resolve().parent.parent.joinpath("../data/Falls_Data.xlsx")
-        )
-        self.fall_s_z_paths = None
-        self.fall_df = pd.read_excel(fall_df_path)
-        self.fall_st = StagedTree(
-            dataframe=self.fall_df,
-            sampling_zero_paths=self.fall_s_z_paths,
-        )
+    # def setup(self):
+    #     """Test setup"""
+    #     # pylint: disable=attribute-defined-outside-init
+    #     # stratified dataset
+    #     med_df_path = (
+    #         Path(__file__)
+    #         .resolve()
+    #         .parent.parent.joinpath("../data/medical_dm_modified.xlsx")
+    #     )
+    #     self.med_s_z_paths = None
+    #     self.med_df = pd.read_excel(med_df_path)
+    #     self.med_st = StagedTree(
+    #         dataframe=self.med_df, sampling_zero_paths=self.med_s_z_paths
+    #     )
 
-    def test_run_ahc_before_figure(self) -> None:
+    #     # non-stratified dataset
+    #     fall_df_path = (
+    #         Path(__file__).resolve().parent.parent.joinpath("../data/Falls_Data.xlsx")
+    #     )
+    #     self.fall_s_z_paths = None
+    #     self.fall_df = pd.read_excel(fall_df_path)
+    #     self.fall_st = StagedTree(
+    #         dataframe=self.fall_df,
+    #         sampling_zero_paths=self.fall_s_z_paths,
+    #     )
+
+    def test_run_ahc_before_figure(self, med_st) -> None:
         """Tests expected error message is in the log when running without
         running AHC"""
         try:
-            self.med_st.create_figure()
+            med_st.create_figure()
 
         except (InvocationException):
             pass

--- a/src/tests/test_staged.py
+++ b/src/tests/test_staged.py
@@ -30,32 +30,6 @@ class TestLogging:
         )
         return med_st
 
-    # def setup(self):
-    #     """Test setup"""
-    #     # pylint: disable=attribute-defined-outside-init
-    #     # stratified dataset
-    #     med_df_path = (
-    #         Path(__file__)
-    #         .resolve()
-    #         .parent.parent.joinpath("../data/medical_dm_modified.xlsx")
-    #     )
-    #     self.med_s_z_paths = None
-    #     self.med_df = pd.read_excel(med_df_path)
-    #     self.med_st = StagedTree(
-    #         dataframe=self.med_df, sampling_zero_paths=self.med_s_z_paths
-    #     )
-
-    #     # non-stratified dataset
-    #     fall_df_path = (
-    #         Path(__file__).resolve().parent.parent.joinpath("../data/Falls_Data.xlsx")
-    #     )
-    #     self.fall_s_z_paths = None
-    #     self.fall_df = pd.read_excel(fall_df_path)
-    #     self.fall_st = StagedTree(
-    #         dataframe=self.fall_df,
-    #         sampling_zero_paths=self.fall_s_z_paths,
-    #     )
-
     def test_run_ahc_before_figure(self, med_st) -> None:
         """Tests expected error message is in the log when running without
         running AHC"""

--- a/src/tests/test_staged.py
+++ b/src/tests/test_staged.py
@@ -25,9 +25,7 @@ class TestLogging:
         )
         med_s_z_paths = None
         med_df = pd.read_excel(med_df_path)
-        med_st = StagedTree(
-            dataframe=med_df, sampling_zero_paths=med_s_z_paths
-        )
+        med_st = StagedTree(dataframe=med_df, sampling_zero_paths=med_s_z_paths)
         return med_st
 
     def test_run_ahc_before_figure(self, med_st) -> None:


### PR DESCRIPTION
As the requirements are set as >=, some of the dependencies were causing issues. This was especially true with pytest, where setup is no longer used.

Some were fixed by creating fixtures, others were fixed by using unittest.TestCase instead.