### PR TITLE
Update to documentation

### DIFF
--- a/docs/quickstart/quickstart_staged_tree_notebook.ipynb
+++ b/docs/quickstart/quickstart_staged_tree_notebook.ipynb
@@ -230,11 +230,11 @@
     "### Prior parameters\n",
     "\n",
     "`cegpy` uses a Bayesian scoring function within the AHC algorithm and so requires specification of prior distributions for the transition parameter vectors. This is done via conjugate Dirichlet priors and so only requires specification of the Dirichlet parameters for each situation. \n",
-    "The default choice of Dirichlet parameters follows the score equivalence prior for stratified trees . \n",
+    "The default choice of Dirichlet parameters follows the score equivalence prior for stratified trees [(Cowell and Smith, 2014)](https://projecteuclid.org/journals/electronic-journal-of-statistics/volume-8/issue-1/Causal-discovery-through-MAP-selection-of-stratified-chain-event-graphs/10.1214/14-EJS917.full). \n",
     "The size of the default parameters are controlled by the optional parameter `alpha` passed to `calculate_AHC_transitions`. Larger values of `alpha` give stronger priors and therefore probability estimates that are less sensitive to the data. \n",
     "\n",
     "Different prior parameters can be provided using the parameter `prior` in `calculate_AHC_transitions`. This is in the format of a list of lists where each sublist contains the prior parameters for a situation (ordered by node index) for each outgoing edge (in alphabetical order by edge label). Parameter values must be in the form of a `Fraction` from the `fractions` package. \n",
-    "For example, below we make all prior parameters equal to 1. In `create_figure`, the `edge_info` parameter can be used to display the "prior" parameters in the staged tree."
+    "For example, below we make all prior parameters equal to 1. In `create_figure`, the `edge_info` parameter can be used to display the 'prior' parameters in the staged tree."
    ]
   },
   {

--- a/docs/quickstart/quickstart_staged_tree_notebook.ipynb
+++ b/docs/quickstart/quickstart_staged_tree_notebook.ipynb
@@ -156,6 +156,35 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Initial staging\n",
+    "\n",
+    "By default, the AHC algorithm initialises with all situations in different stages. It then greadily merges pairs of stages until the scoring function cannot be increased further. In this way it is possible, a priori, for any two situations in the same hyperstage to be put in the same stage.\n",
+    "However, sometimes prior information is available, through either elicited expert knowledge or previous studies, that says two situations are in the same stage. In this case, the corresponding situations should be placed in the same stage regardless of the data or model selection algorithm.\n",
+    "\n",
+    "This can be done in `cegpy` using the `initial_staging` argument within `calculate_AHC_transitions`. The `initial_staging` is a list of lists where each sublist is a group of situations (that must be in the same hyperstage) that are forced to be in the same stage. Note that not every situation has to appear in the `initial_staging`, only those that should be merged a-priori.\n",
+    "The AHC algorithm is then initialised with the stages specified in `initial_staging`. Because the AHC algorithm does not allow stages to be split in the search, these merged situations will remain in the final selected model.\n",
+    "\n",
+    "For example, suppose we know a-priori that for experienced individuals, the response does not depend on the difficulty of the classification task. That is, $s_9$ and $s_{10}$ must be in the same stage, as well as $s_{15}$ and $s_{16}$. This is implemented using the `initial_staging` as shown below. Notice that the relevant situations remain in the same stage after execution of the AHC algorithm.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_initial_staging = [\n",
+    "    ['s9', 's10'], \n",
+    "    ['s15', 's16'], \n",
+    "]\n",
+    "st.calculate_AHC_transitions(initial_staging=new_initial_staging)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Structural and sampling zeros / missing values\n",
     "\n",
     "The package, by default, treats all blank and `NaN` cells as *structural* missing values, i.e. data that is missing for a logical reason. However, sometimes these instead occur due to sampling limitations; *sampling* missing values. Similarly, when a certain value for a variable is not observed in the data set (given its ancestral variables), the package by default assumes that this combination of values is impossible to observe - a *structural* zero. This is represented by the corresponding edge being omitted from the event tree. However, this might instead be a *sampling* zero - the combination of values is possible but does not appear in the data set.\n",

--- a/docs/quickstart/quickstart_staged_tree_notebook.ipynb
+++ b/docs/quickstart/quickstart_staged_tree_notebook.ipynb
@@ -131,9 +131,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example, situations $s_1$ and $s_2$ belong to the same hyperstage. Each of them has three emanating edges with labels *Experienced*, *Inexperienced*, and *Novice*. However, stages $s_6$ and $s_15$ belong to different hyperstages. They both have two emanating edges, yet different labels: *Easy*, *Hard* and *Blast*, *Non-blast*.\n",
+    "In this example, situations $s_1$ and $s_2$ belong to the same hyperstage. Both of them have three emanating edges with labels *Experienced*, *Inexperienced*, and *Novice*. However, stages $s_6$ and $s_{15}$ belong to different hyperstages. They both have two emanating edges, yet different labels: *Easy*, *Hard* and *Blast*, *Non-blast*.\n",
     "\n",
-    "We can specify a different hyperstage at the point of running the AHC algorithm by passing a list defining the hyperstage partition as a parameter to the `calculate_AHC_transitions` method, for example:"
+    "We can specify a different hyperstage at the point of running the AHC algorithm by passing a list defining the hyperstage partition as a parameter to the `calculate_AHC_transitions` method, for example separating the binary classification at $s_0$ from the response:"
    ]
   },
   {
@@ -144,9 +144,9 @@
    "source": [
     "new_hyperstage = [\n",
     "    ['s0'], \n",
-    "    ['s3', 's4', 's5', 's6', 's7', 's8', 's9', 's10', 's11', 's12', \n",
-    "    's13', 's14', 's15', 's16', 's17', 's18', 's19','s20'],\n",
-    "    ['s1', 's2'],\n",
+    "    ['s1', 's2'], \n",
+    "    ['s3', 's4', 's5', 's6', 's7', 's8'], \n",
+    "    ['s9', 's10', 's11', 's12', 's13', 's14', 's15', 's16', 's17', 's18', 's19','s20'], \n",
     "]\n",
     "st.calculate_AHC_transitions(hyperstage=new_hyperstage)"
    ]
@@ -158,7 +158,7 @@
    "source": [
     "### Structural and sampling zeros / missing values\n",
     "\n",
-    "The package, by default, treats all blank and `NaN` cells as *structural* missing values, i.e. data that is missing for a logical reason. However, sometimes these might occur due to sampling limitations; *sampling* missing values. We may also not observe a certain value for a variable in our data set (given its ancestral variables) not because that value is a structural zero but because of sampling limitations, in which case we are dealing with *sampling zeros*.\n",
+    "The package, by default, treats all blank and `NaN` cells as *structural* missing values, i.e. data that is missing for a logical reason. However, sometimes these instead occur due to sampling limitations; *sampling* missing values. Similarly, when a certain value for a variable is not observed in the data set (given its ancestral variables), the package by default assumes that this combination of values is impossible to observe - a *structural* zero. This is represented by the corresponding edge being omitted from the event tree. However, this might instead be a *sampling* zero - the combination of values is possible but does not appear in the data set.\n",
     "\n",
     "Consider the following example of the `falls.xlsx` data set which provides information concerning adults over the age of 65, and includes four categorical variables as given below with their state spaces:\n",
     "- **Housing Assessment**: Living situation and whether they have been assessed, state space: `{\"Communal Assessed\", \"Communal Not Assessed\", \"Community Assessed\", \"Community Not Assessed\"}`;\n",
@@ -192,7 +192,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Observe that this process has structural asymmetries. None of the individuals assessed to be low risk are referred to the falls clinic and thus, for this group, the count associated with the _Referred \\& Treated’}$ category is a structural zero:"
+    "Observe that this process has some asymmetries. None of the individuals assessed to be low risk are referred to the falls clinic and thus, for this group, the count associated with the *Referred & Treated* category is zero and these edges are not included in the tree."
    ]
   },
   {
@@ -209,7 +209,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Moreover, for individuals who are not assessed, their responses are structurally missing for the `Treatment` variable:"
+    "Furthermore, for individuals who are not assessed, the `Treatment` variable is not recorded and appears as `NaN` in the dataset:"
    ]
   },
   {
@@ -233,7 +233,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In `cegpy` any paths that should logically be in the event tree description of the process but are absent from the dataset due to sampling limitations would need to be manually added by the user using the sampling zero paths argument when initialising the `EventTree` object. Further, not all missing values in the dataset will be structurally missing. "
+    "By default, these are assumed to be structural zeros and missing values. That is, individuals assessed as low risk are never referred - a structural zero - and it does not make sense to consider referral and treatment of individuals that are not assessed - structural missing values. If either of these are not the case and the zeros or missing values are due to limitations of the sample, then this can be specified as demonstrated below."
    ]
   },
   {
@@ -241,9 +241,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### How to distinguish between structural and sampling missing values?\n",
+    "#### Distinguishing structural and sampling missing values\n",
     "    \n",
-    "e.g. Falls example: Suppose that some individuals in communal establishments who are not formally assessed but are known to be high risk were actually either `\"Not Referred & Treated\"` or `\"Not Referred & Not Treated\"` but that these observations were missing in the `falls.xlsx` dataset due to sampling limitations. All the other blank/`NaN` cells are structurally missing."
+    "Suppose that some individuals in communal establishments that were not formally assessed but were known to be high risk actually received treatment, but that this was not recorded in the dataset. The treatment of such individuals are therefore sampling missing values, while the other blank/`NaN` cells are structurally missing."
    ]
   },
   {
@@ -280,7 +280,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next step is to tell the `EventTree` or `StagedTree` object about these missing value arguments as shown below. This will generate a new path along `Communal Not Assessed', `High Risk', `missing')}$:"
+    "By providing this as the `missing_label` in the `EventTree` (or `StagedTree`) object, the corresponding path - `(\"Communal Not Assessed\", \"High Risk\", \"missing\")` is added to the event tree:"
    ]
   },
   {
@@ -300,11 +300,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### How to add sampling zeros?\n",
+    "#### Adding sampling zeros\n",
     "\n",
-    "e.g. Falls example: Suppose that some individuals in the community who were assessed and high risk were referred and not treated. Suppose that our observations are still the same as in the `falls.xlsx` dataset. Here, by design, this was allowed, but was not observed in the dataset. So we need to add this value in manually as a path `(\"Community Assessed\", \"High Risk\", \"Referred & Not Treated\")`. We also need to add in the values that follow it: i.e. `(\"Community Assessed\", \"High Risk\", \"Referred & Not Treated\", \"Fall\")` and `(\"Community Assessed\", \"High Risk\", \"Referred & Not Treated\", \"Don't Fall\")`.\n",
+    "Suppose that some individuals in the community who were assessed and high risk were referred and not treated, but that none of these individuals appeared in the dataset. This path `(\"Community Assessed\", \"High Risk\", \"Referred & Not Treated\")` should appear in the event tree, but because it is not in the dataset this must be done manually. We also need to add in the values that follow it: i.e. `(\"Community Assessed\", \"High Risk\", \"Referred & Not Treated\", \"Fall\")` and `(\"Community Assessed\", \"High Risk\", \"Referred & Not Treated\", \"Don't Fall\")`.\n",
     "\n",
-    "In `cegpy` any paths that should logically be in the event tree description of the process but are absent from the dataset due to sampling limitations would need to be manually added by the user using the sampling zero paths argument when initialising the `EventTree` or `StagedTree` object. No changes need to be made to the dataset, as shown below:"
+    "In `cegpy` any paths that should be in the event tree but are absent from the dataset can be added manually by the user using the `sampling_zero_paths` argument when initialising the `EventTree` or `StagedTree` object. No changes need to be made to the dataset, as shown below:"
    ]
   },
   {

--- a/docs/quickstart/quickstart_staged_tree_notebook.ipynb
+++ b/docs/quickstart/quickstart_staged_tree_notebook.ipynb
@@ -237,23 +237,7 @@
     "For example, below we make all prior parameters equal to 1. In `create_figure`, the `edge_info` parameter can be used to display the "prior" parameters in the staged tree."
    ]
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from fractions import Fraction \n",
-    "new_prior = list() \n",
-    "new_prior.append([Fraction(1, 1), Fraction(1, 1)]) \n",
-    "for i in range(2): \n",
-    "  new_prior.append([Fraction(1, 1), Fraction(1, 1), Fraction(1,1)]) \n",
-    "for i in range(18): \n",
-    "  new_prior.append([Fraction(1, 1), Fraction(1, 1)]) \n",
-    "st.calculate_AHC_transitions(prior=new_prior) \n",
-    "st.create_figure(edge_info='prior')"
-   ]
-  },
+  
   {
    "attachments": {},
    "cell_type": "markdown",

--- a/docs/quickstart/quickstart_staged_tree_notebook.ipynb
+++ b/docs/quickstart/quickstart_staged_tree_notebook.ipynb
@@ -222,22 +222,24 @@
     "st.calculate_AHC_transitions(hyperstage=custom_staging, initial_staging=custom_staging)"
    ]
   },
+  
   {
-   "attachments": {},
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "### Prior parameters\n",
-    "\n",
-    "`cegpy` uses a Bayesian scoring function within the AHC algorithm and so requires specification of prior distributions for the transition parameter vectors. This is done via conjugate Dirichlet priors and so only requires specification of the Dirichlet parameters for each situation.\n",
-    "The default choice of Dirichlet parameters follows the score equivalence prior for stratified trees [(Cowell and Smith, 2014)](https://projecteuclid.org/journals/electronic-journal-of-statistics/volume-8/issue-1/Causal-discovery-through-MAP-selection-of-stratified-chain-event-graphs/10.1214/14-EJS917.full).\n",
-    "The size of the default parameters are controlled by the optional parameter `alpha` passed to `calculate_AHC_transitions`. Larger values of `alpha` give stronger priors and therefore probability estimates that are less sensitive to the data.\n",
-    "\n",
-    "Different prior parameters can be provided using the parameter `prior` in `calculate_AHC_transitions`. This is in the format of a list of lists where each sublist contains the prior parameters for a situation (ordered by node index) for each outgoing edge (in alphabetical order by edge label). Parameter values must be in the form of a `Fractions` from the `fractions` package. \n",
-    "For example, below we make all prior parameters equal to 1. In `create_figure`, the `edge_info` parameter can be used to display the "prior" parameters in the staged tree."
+    "from fractions import Fraction \n",
+    "new_prior = list() \n",
+    "new_prior.append([Fraction(1, 1), Fraction(1, 1)]) \n",
+    "for i in range(2): \n",
+    "  new_prior.append([Fraction(1, 1), Fraction(1, 1), Fraction(1,1)]) \n",
+    "for i in range(18): \n",
+    "  new_prior.append([Fraction(1, 1), Fraction(1, 1)]) \n",
+    "st.calculate_AHC_transitions(prior=new_prior) \n",
+    "st.create_figure(edge_info='prior')"
    ]
   },
-  
   {
    "attachments": {},
    "cell_type": "markdown",

--- a/docs/quickstart/quickstart_staged_tree_notebook.ipynb
+++ b/docs/quickstart/quickstart_staged_tree_notebook.ipynb
@@ -164,7 +164,7 @@
     "This can be done in `cegpy` using the `initial_staging` argument within `calculate_AHC_transitions`. The `initial_staging` is a list of lists where each sublist is a group of situations (that must be in the same hyperstage) that are forced to be in the same stage. Note that not every situation has to appear in the `initial_staging`, only those that should be merged a-priori.\n",
     "The AHC algorithm is then initialised with the stages specified in `initial_staging`. Because the AHC algorithm does not allow stages to be split in the search, these merged situations will remain in the final selected model.\n",
     "\n",
-    "For example, suppose we know a-priori that for experienced individuals, the response does not depend on the difficulty of the classification task. That is, $s_9$ and $s_{10}$ must be in the same stage, as well as $s_{15}$ and $s_{16}$. This is implemented using the `initial_staging` as shown below. Notice that the relevant situations remain in the same stage after execution of the AHC algorithm.\n"
+    "For example, suppose we know a-priori that for experienced individuals, the response does not depend on the difficulty of the classification task. That is, $s_9$ and $s_{10}$ must be in the same stage, as well as $s_{15}$ and $s_{16}$. This is implemented using the `initial_staging` as shown below. Notice that the relevant situations remain in the same stage after execution of the AHC algorithm."
    ]
   },
   {
@@ -193,7 +193,7 @@
     "\n",
     "To do this, simply write the custom staging as a list of lists and pass this as both the `hyperstage` and `initial_staging` parameters in `calculate_AHC_transitions`. The algorithm is initialised at `initial_staging`, but because this is identical to `hyperstage` it is not possible to further merge any stages. Hence the AHC algorithm will terminate immediately with the custom staging.\n",
     "\n",
-    "For example, suppose we wish to combine all situations regarding experience level together and combine all situations regarding difficulty rating, but keep all situations regarding the binary classification and response separate:\n"
+    "For example, suppose we wish to combine all situations regarding experience level together and combine all situations regarding difficulty rating, but keep all situations regarding the binary classification and response separate:"
    ]
   },
   {
@@ -234,7 +234,7 @@
     "The size of the default parameters are controlled by the optional parameter `alpha` passed to `calculate_AHC_transitions`. Larger values of `alpha` give stronger priors and therefore probability estimates that are less sensitive to the data.\n",
     "\n",
     "Different prior parameters can be provided using the parameter `prior` in `calculate_AHC_transitions`. This is in the format of a list of lists where each sublist contains the prior parameters for a situation (ordered by node index) for each outgoing edge (in alphabetical order by edge label). Parameter values must be in the form of a `Fractions` from the `fractions` package. \n",
-    "For example, below we make all prior parameters equal to 1. In `create_figure`, the `edge_info` parameter can be used to display the "prior" parameters in the staged tree. \n"
+    "For example, below we make all prior parameters equal to 1. In `create_figure`, the `edge_info` parameter can be used to display the "prior" parameters in the staged tree."
    ]
   },
   {
@@ -251,7 +251,7 @@
     "for i in range(18): \n",
     "  new_prior.append([Fraction(1, 1), Fraction(1, 1)]) \n",
     "st.calculate_AHC_transitions(prior=new_prior) \n",
-    "st.create_figure(edge_info='prior') \n"
+    "st.create_figure(edge_info='prior')"
    ]
   },
   {

--- a/docs/quickstart/quickstart_staged_tree_notebook.ipynb
+++ b/docs/quickstart/quickstart_staged_tree_notebook.ipynb
@@ -15,14 +15,14 @@
    "source": [
     "## EventTree Class\n",
     "\n",
-    "The first starting point in constructing a Chain Event Graph (CEG) is to create \n",
+    "The first step in constructing a Chain Event Graph (CEG) is to create \n",
     "an event tree describing the process being studied. An event tree is a directed \n",
     "tree graph with a single root node. The nodes with no emanating edges are\n",
     "called *leaves*, and the non-leaf nodes are called *situations*. \n",
     "\n",
-    "In this example we work with a data set which contains 4 categorical variables; *Classification*, *Group*, *Difficulty*, and *Response*.\n",
+    "In this example we work with a data set of four categorical variables: *Classification*, *Group*, *Difficulty*, and *Response*.\n",
     "\n",
-    "Each individual is given a binary classification; *Blast* or *Non-blast*. Each group is rated on their experience level: *Experienced*, *Inexperienced*, or *Novice*. The classification task they are given has a difficulty rating of *Easy* or *Hard*. Finally, their response is shown: *Blast* or *Non-blast*.\n",
+    "Each individual is given a binary classification - *Blast* or *Non-blast* - and are rated on their experience level - *Experienced*, *Inexperienced*, or *Novice*. The classification task they are given has a difficulty rating of *Easy* or *Hard* and the response can be either *Blast* or *Non-blast*.\n",
     "\n",
     "We begin by importing the data set and initializing the `EventTree` object, as shown below:"
    ]
@@ -67,14 +67,14 @@
    "source": [
     "## StagedTree Class\n",
     "\n",
-    "In an event tree, each situation is associated with a transition parameter vector which indicates the conditional\n",
-    "probability of an individual, who has arrived at the situation, going along one of its edges. In order to create a CEG, we first need to elicit a *staged tree*. \n",
-    "This is done by first partitioning situations into *stages*, which are collections of situations in the event tree whose immediate evolutions, i.e. their associated conditional transition parameter vectors, are equivalent. To indicate this symmetry, all situations in the same stage are assigned a single colour.\n",
+    "In an event tree, each situation is associated with a transition parameter vector which gives the conditional\n",
+    "probability distribution of an individual, who has arrived at the situation, going along each of its edges. In order to create a CEG, we first need to select a *staged tree*. \n",
+    "A staged tree is a probabilistic model which partitions the situations of an event tree into *stages*. A stage is a collection of situations in the event tree whose immediate evolutions, i.e. their associated transition parameter vectors, are equivalent. To display this symmetry, all situations in the same stage are assigned a single colour.\n",
     "\n",
-    "Identification of the stages in the event tree can be done using any suitable model selection algorithm. Currently, the only available selection algorithm in `cegpy` is the *Agglomerative Hierarchical Clustering (AHC)* algorithm [(Freeman and Smith, 2011)](https://warwick.ac.uk/fac/sci/statistics/research/graphicalbayes/bayesian_map_model_selection_of_chain_event_graphs.pdf).\n",
+    "Selection of a stage tree model for a given event tree can be done using any suitable model selection algorithm. Currently, the only available selection algorithm in `cegpy` is the *Agglomerative Hierarchical Clustering (AHC)* algorithm [(Freeman and Smith, 2011)](https://warwick.ac.uk/fac/sci/statistics/research/graphicalbayes/bayesian_map_model_selection_of_chain_event_graphs.pdf).\n",
     "\n",
-    "In order to create a staged tree in `cegpy` we first initialize a `StagedTree` object from the dataset and then run the AHC algorithm using the `create_AHC_transitions` method, as displayed below. The output of the AHC algorithm is a dictionary containing the following information:\n",
-    "- `Merged Situations` - a list of tuples representing the partition of the nodes into stages\n",
+    "In order to create a staged tree in `cegpy` we first initialize a `StagedTree` object from the dataset and then run the AHC algorithm using the `create_AHC_transitions` method, as displayed below. The output of the AHC algorithm is a dictionary containing the:\n",
+    "- `Merged Situations` - a list of tuples representing the partition of the situations into stages\n",
     "- `Log Likelihood` - the log likelihood of the data under the model selected by AHC"
    ]
   },
@@ -95,7 +95,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Within `cegpy`, singleton stages, i.e. stages containing a single situation, are coloured white, leaves and their corresponding sink node are coloured in light-grey. Running AHC on our data set results in the following staged tree."
+    "Within `cegpy`, singleton stages, i.e. stages containing a single situation, are coloured white, while the leaves are coloured in light-grey. Running AHC on our data set results in the following staged tree."
    ]
   },
   {
@@ -114,7 +114,7 @@
    "source": [
     "### Custom Hyperstages\n",
     "\n",
-    "`cegpy` allows the user to specify which situations are allowed to be merged by the AHC algorithm. This is done by specifying a *hyperstage* [(Collazo et al., 2017)](http://wrap.warwick.ac.uk/91075/1/WRAP_Theses_Collazo_2017.pdf) which is a collection of sets such that two situations cannot be in the same stage unless they belong to the same set in the hyperstage. Under a default setting in `cegpy`, all situations which have the same number of outgoing edges and equivalent set of edge labels are in the same set within the hyperstage. The default hyperstages of a given tree can be displayed by accessing the `hyperstage` property, which returns a list of lists, where each sublist contains situations belonging to the same hyperstage."
+    "`cegpy` allows the user to specify which situations are allowed to be placed in the same stage by the AHC algorithm. This is done by specifying a *hyperstage* [(Collazo et al., 2017)](http://wrap.warwick.ac.uk/91075/1/WRAP_Theses_Collazo_2017.pdf) which is a collection of sets such that two situations cannot be in the same stage unless they belong to the same set in the hyperstage. Under a default setting in `cegpy`, all situations which have the same number of outgoing edges and equivalent set of edge labels are in the same set within the hyperstage. The default hyperstages of a given tree can be displayed by accessing the `hyperstage` property, which returns a list of lists, where each sublist contains situations belonging to the same hyperstage."
    ]
   },
   {
@@ -161,10 +161,10 @@
     "The package, by default, treats all blank and `NaN` cells as *structural* missing values, i.e. data that is missing for a logical reason. However, sometimes these instead occur due to sampling limitations; *sampling* missing values. Similarly, when a certain value for a variable is not observed in the data set (given its ancestral variables), the package by default assumes that this combination of values is impossible to observe - a *structural* zero. This is represented by the corresponding edge being omitted from the event tree. However, this might instead be a *sampling* zero - the combination of values is possible but does not appear in the data set.\n",
     "\n",
     "Consider the following example of the `falls.xlsx` data set which provides information concerning adults over the age of 65, and includes four categorical variables as given below with their state spaces:\n",
-    "- **Housing Assessment**: Living situation and whether they have been assessed, state space: `{\"Communal Assessed\", \"Communal Not Assessed\", \"Community Assessed\", \"Community Not Assessed\"}`;\n",
-    "- **Risk**: Risk of a future fall, state space: `{\"High Risk\", \"Low Risk\"}`;\n",
-    "- **Treatment**: Referral and treatment status, state space: `{\"Not Referred & Not Treated\", \"Not Referred & Treated\", \"Referred & Treated\"}`;\n",
-    "- **Fall**: the outcome, state space: `{\"Fall\", \"Don’t Fall\"}`."
+    "- **Housing Assessment**: Living situation and whether they have been assessed. State space: `{\"Communal Assessed\", \"Communal Not Assessed\", \"Community Assessed\", \"Community Not Assessed\"}`;\n",
+    "- **Risk**: Risk of a future fall. State space: `{\"High Risk\", \"Low Risk\"}`;\n",
+    "- **Treatment**: Referral and treatment status. State space: `{\"Not Referred & Not Treated\", \"Not Referred & Treated\", \"Referred & Treated\"}`;\n",
+    "- **Fall**: The outcome. State space: `{\"Fall\", \"Don’t Fall\"}`."
    ]
   },
   {
@@ -192,7 +192,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Observe that this process has some asymmetries. None of the individuals assessed to be low risk are referred to the falls clinic and thus, for this group, the count associated with the *Referred & Treated* category is zero and these edges are not included in the tree."
+    "Observe that this process has some asymmetries. None of the individuals assessed to be low risk are referred to the falls clinic and thus, for these groups, the count associated with the *Referred & Treated* category is zero and these edges are not included in the tree."
    ]
   },
   {

--- a/docs/quickstart/quickstart_staged_tree_notebook.ipynb
+++ b/docs/quickstart/quickstart_staged_tree_notebook.ipynb
@@ -185,6 +185,48 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Custom staged trees\n",
+    "\n",
+    "`cegpy` is only able to draw a staged tree and display estimated transition probabilities after running `calculate_AHC_transitions`. This means that it is only possible to display the staged tree selected by the AHC algorithm.\n",
+    "However, by combining the `hyperstage` and `initial_staging` parameters, one is able to draw and estimate transition probabilities of a user defined staged tree.\n",
+    "This might be useful, for example, for comparing two different staged trees or for estimating probabilities in a staged tree where the stages are completely informed by prior information.\n",
+    "\n",
+    "To do this, simply write the custom staging as a list of lists and pass this as both the `hyperstage` and `initial_staging` parameters in `calculate_AHC_transitions`. The algorithm is initialised at `initial_staging`, but because this is identical to `hyperstage` it is not possible to further merge any stages. Hence the AHC algorithm will terminate immediately with the custom staging.\n",
+    "\n",
+    "For example, suppose we wish to combine all situations regarding experience level together and combine all situations regarding difficulty rating, but keep all situations regarding the binary classification and response separate:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "custom_staging = [\n",
+    "    ['s0'], \n",
+    "    ['s1', 's2'], \n",
+    "    ['s3', 's4', 's5', 's6', 's7', 's8'], \n",
+    "    ['s9'], \n",
+    "    ['s10'], \n",
+    "    ['s11'], \n",
+    "    ['s12'], \n",
+    "    ['s13'], \n",
+    "    ['s14'], \n",
+    "    ['s15'], \n",
+    "    ['s16'], \n",
+    "    ['s17'], \n",
+    "    ['s18'], \n",
+    "    ['s19'], \n",
+    "    ['s20'], \n",
+    "]\n",
+    "st.calculate_AHC_transitions(hyperstage=custom_staging, initial_staging=custom_staging)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Structural and sampling zeros / missing values\n",
     "\n",
     "The package, by default, treats all blank and `NaN` cells as *structural* missing values, i.e. data that is missing for a logical reason. However, sometimes these instead occur due to sampling limitations; *sampling* missing values. Similarly, when a certain value for a variable is not observed in the data set (given its ancestral variables), the package by default assumes that this combination of values is impossible to observe - a *structural* zero. This is represented by the corresponding edge being omitted from the event tree. However, this might instead be a *sampling* zero - the combination of values is possible but does not appear in the data set.\n",

--- a/docs/quickstart/quickstart_staged_tree_notebook.ipynb
+++ b/docs/quickstart/quickstart_staged_tree_notebook.ipynb
@@ -227,6 +227,38 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Prior parameters\n",
+    "\n",
+    "`cegpy` uses a Bayesian scoring function within the AHC algorithm and so requires specification of prior distributions for the transition parameter vectors. This is done via conjugate Dirichlet priors and so only requires specification of the Dirichlet parameters for each situation.\n",
+    "The default choice of Dirichlet parameters follows the score equivalence prior for stratified trees [(Cowell and Smith, 2014)](https://projecteuclid.org/journals/electronic-journal-of-statistics/volume-8/issue-1/Causal-discovery-through-MAP-selection-of-stratified-chain-event-graphs/10.1214/14-EJS917.full).\n",
+    "The size of the default parameters are controlled by the optional parameter `alpha` passed to `calculate_AHC_transitions`. Larger values of `alpha` give stronger priors and therefore probability estimates that are less sensitive to the data.\n",
+    "\n",
+    "Different prior parameters can be provided using the parameter `prior` in `calculate_AHC_transitions`. This is in the format of a list of lists where each sublist contains the prior parameters for a situation (ordered by node index) for each outgoing edge (in alphabetical order by edge label). Parameter values must be in the form of a `Fractions` from the `fractions` package. \n",
+    "For example, below we make all prior parameters equal to 1. In `create_figure`, the `edge_info` parameter can be used to display the "prior" parameters in the staged tree. \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fractions import Fraction \n",
+    "new_prior = list() \n",
+    "new_prior.append([Fraction(1, 1), Fraction(1, 1)]) \n",
+    "for i in range(2): \n",
+    "  new_prior.append([Fraction(1, 1), Fraction(1, 1), Fraction(1,1)]) \n",
+    "for i in range(18): \n",
+    "  new_prior.append([Fraction(1, 1), Fraction(1, 1)]) \n",
+    "st.calculate_AHC_transitions(prior=new_prior) \n",
+    "st.create_figure(edge_info='prior') \n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Structural and sampling zeros / missing values\n",
     "\n",
     "The package, by default, treats all blank and `NaN` cells as *structural* missing values, i.e. data that is missing for a logical reason. However, sometimes these instead occur due to sampling limitations; *sampling* missing values. Similarly, when a certain value for a variable is not observed in the data set (given its ancestral variables), the package by default assumes that this combination of values is impossible to observe - a *structural* zero. This is represented by the corresponding edge being omitted from the event tree. However, this might instead be a *sampling* zero - the combination of values is possible but does not appear in the data set.\n",

--- a/docs/quickstart/quickstart_staged_tree_notebook.ipynb
+++ b/docs/quickstart/quickstart_staged_tree_notebook.ipynb
@@ -222,7 +222,21 @@
     "st.calculate_AHC_transitions(hyperstage=custom_staging, initial_staging=custom_staging)"
    ]
   },
-  
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Prior parameters\n",
+    "\n",
+    "`cegpy` uses a Bayesian scoring function within the AHC algorithm and so requires specification of prior distributions for the transition parameter vectors. This is done via conjugate Dirichlet priors and so only requires specification of the Dirichlet parameters for each situation. \n",
+    "The default choice of Dirichlet parameters follows the score equivalence prior for stratified trees . \n",
+    "The size of the default parameters are controlled by the optional parameter `alpha` passed to `calculate_AHC_transitions`. Larger values of `alpha` give stronger priors and therefore probability estimates that are less sensitive to the data. \n",
+    "\n",
+    "Different prior parameters can be provided using the parameter `prior` in `calculate_AHC_transitions`. This is in the format of a list of lists where each sublist contains the prior parameters for a situation (ordered by node index) for each outgoing edge (in alphabetical order by edge label). Parameter values must be in the form of a `Fraction` from the `fractions` package. \n",
+    "For example, below we make all prior parameters equal to 1. In `create_figure`, the `edge_info` parameter can be used to display the "prior" parameters in the staged tree."
+   ]
+  },
   {
    "cell_type": "code",
    "execution_count": null,

--- a/src/cegpy/trees/_staged.py
+++ b/src/cegpy/trees/_staged.py
@@ -623,7 +623,7 @@ class StagedTree(EventTree):
                     if situ_pair[1] in comb:
                         hyperstage_combinations.remove(comb)
 
-        while True:
+        while len(hyperstage_combinations) != 0:
             newscores_list = [
                 self._calculate_bayes_factor(
                     priors[self.situations.index(sub_hyper[0])],

--- a/src/cegpy/trees/_staged.py
+++ b/src/cegpy/trees/_staged.py
@@ -756,6 +756,11 @@ class StagedTree(EventTree):
             Otherwise, colours evenly spaced around the colour spectrum are used.
         :type colour_list: List[str]
 
+        :param initial_staging: Optional - Specifies groups of nodes which are forced to 
+            be in the same stage before the AHC selection algorithm is run. Each list is 
+            a list of node names e.g. "s0".
+        :type initial_staging: List[List[str]]
+
         :return: The output from the AHC algorithm, specified above.
         :rtype: Dict
         """


### PR DESCRIPTION
Various updates to the documentation, mostly on the 'Creation of a staged tree' page.

- Added 'initial_staging' to the parameter list for 'calculate_AHC_transitions'
- Minor changes to existing 'Creation of a staged tree' page to hopefully improve clarity, plus some typo fixes.
- Addition of new sections on 'Initial staging', 'Custom staged trees' and 'Prior parameters'.

For the new sections, I might have focussed too much on how the methods work rather than how to use them. If you think this is the case, let me know and I can edit.