### PR TITLE
Feature edge_info=none

### DIFF
--- a/src/cegpy/graphs/_ceg.py
+++ b/src/cegpy/graphs/_ceg.py
@@ -190,11 +190,9 @@ class ChainEventGraph(nx.MultiDiGraph):
 
     def dot_graph(self, edge_info: str = "probability") -> pdp.Dot:
         """Returns Dot graph representation of the CEG.
-        :param edge_info: Optional - Chooses which summary measure to be displayed
-        on edges. Defaults to "count".
-        Options: ["count", "prior", "posterior", "probability"]
-
+        :param edge_info: Optional - Chooses which summary measure to be displayed on edges. Defaults to "count". Options: ["count", "prior", "posterior", "probability", "none"]
         :type edge_info: str
+        
         :return: A graphviz Dot representation of the graph.
         :rtype: pydotplus.Dot"""
         return self._generate_dot_graph(edge_info=edge_info)
@@ -260,8 +258,7 @@ class ChainEventGraph(nx.MultiDiGraph):
 
         :type filename: str
 
-        :param edge_info: Optional - Chooses which summary measure to be displayed on
-            edges. Value can take: "count", "prior", "posterior", "probability"
+        :param edge_info: Optional - Chooses which summary measure to be displayed on edges. Defaults to "count". Options: ["count", "prior", "posterior", "probability", "none"]
         :type edge_info: str
 
         :return: The event tree Image object.

--- a/src/cegpy/graphs/_ceg.py
+++ b/src/cegpy/graphs/_ceg.py
@@ -190,7 +190,7 @@ class ChainEventGraph(nx.MultiDiGraph):
 
     def dot_graph(self, edge_info: str = "probability") -> pdp.Dot:
         """Returns Dot graph representation of the CEG.
-        :param edge_info: Optional - Chooses which summary measure to be displayed on edges. Defaults to "count". Options: ["count", "prior", "posterior", "probability", "none"]
+        :param edge_info: Optional - Chooses which summary measure to be displayed on edges. Defaults to "count". Options: ["count", "prior", "posterior", "probability", "no_info"]
         :type edge_info: str
         
         :return: A graphviz Dot representation of the graph.
@@ -207,7 +207,7 @@ class ChainEventGraph(nx.MultiDiGraph):
         for (src, dst, label), attribute in edge_info_dict.items():
             if edge_info == "count":
                 edge_details = str(label) + "\n" + str(attribute)
-            elif edge_info == "none":
+            elif edge_info == "no_info":
                 edge_details = str(label)
             else:
                 edge_details = f"{label}\n{float(attribute):.2f}"
@@ -258,7 +258,7 @@ class ChainEventGraph(nx.MultiDiGraph):
 
         :type filename: str
 
-        :param edge_info: Optional - Chooses which summary measure to be displayed on edges. Defaults to "count". Options: ["count", "prior", "posterior", "probability", "none"]
+        :param edge_info: Optional - Chooses which summary measure to be displayed on edges. Defaults to "count". Options: ["count", "prior", "posterior", "probability", "no_info"]
         :type edge_info: str
 
         :return: The event tree Image object.

--- a/src/cegpy/graphs/_ceg.py
+++ b/src/cegpy/graphs/_ceg.py
@@ -209,6 +209,8 @@ class ChainEventGraph(nx.MultiDiGraph):
         for (src, dst, label), attribute in edge_info_dict.items():
             if edge_info == "count":
                 edge_details = str(label) + "\n" + str(attribute)
+            elif edge_info == "none":
+                edge_details = str(label)
             else:
                 edge_details = f"{label}\n{float(attribute):.2f}"
 

--- a/src/cegpy/trees/_event.py
+++ b/src/cegpy/trees/_event.py
@@ -236,7 +236,7 @@ class EventTree(nx.MultiDiGraph):
 
     def dot_graph(self, edge_info: str = "count") -> pdp.Dot:
         """Returns Dot graph representation of the event tree.
-        :param edge_info: Optional - Chooses which summary measure to be displayed on edges. Defaults to "count". Options: ["count", "none"]
+        :param edge_info: Optional - Chooses which summary measure to be displayed on edges. Defaults to "count". Options: ["count", "no_info"]
         :type edge_info: str
 
         :type edge_info: str
@@ -256,7 +256,7 @@ class EventTree(nx.MultiDiGraph):
         for edge, attribute in edge_info_dict.items():
             if edge_info == "count":
                 edge_details = str(edge[2]) + "\n" + str(attribute)
-            elif edge_info == "none":
+            elif edge_info == "no_info":
                 edge_details = str(edge[2])
             else:
                 edge_details = f"{edge[2]}\n{float(attribute):.2f}"
@@ -323,7 +323,7 @@ class EventTree(nx.MultiDiGraph):
 
         :type filename: str
 
-        :param edge_info: Optional - Chooses which summary measure to be displayed on edges. Defaults to "count". Options: ["count", "none"]
+        :param edge_info: Optional - Chooses which summary measure to be displayed on edges. Defaults to "count". Options: ["count", "no_info"]
         :type edge_info: str
 
         :return: The event tree Image object.

--- a/src/cegpy/trees/_event.py
+++ b/src/cegpy/trees/_event.py
@@ -324,7 +324,7 @@ class EventTree(nx.MultiDiGraph):
         :type filename: str
 
         :param edge_info: Optional - Chooses which summary measure to be displayed on edges.
-            In event trees, only "count" can be displayed, so this can be omitted.
+            In event trees, the options are "count" or "none".
         :type edge_info: str
 
         :return: The event tree Image object.

--- a/src/cegpy/trees/_event.py
+++ b/src/cegpy/trees/_event.py
@@ -256,6 +256,8 @@ class EventTree(nx.MultiDiGraph):
         for edge, attribute in edge_info_dict.items():
             if edge_info == "count":
                 edge_details = str(edge[2]) + "\n" + str(attribute)
+            elif edge_info == "none":
+                edge_details = str(edge[2])
             else:
                 edge_details = f"{edge[2]}\n{float(attribute):.2f}"
 

--- a/src/cegpy/trees/_event.py
+++ b/src/cegpy/trees/_event.py
@@ -236,8 +236,8 @@ class EventTree(nx.MultiDiGraph):
 
     def dot_graph(self, edge_info: str = "count") -> pdp.Dot:
         """Returns Dot graph representation of the event tree.
-        :param edge_info: Optional - Chooses which summary measure to be displayed on edges.
-        In event trees, only "count" can be displayed, so this can be omitted.
+        :param edge_info: Optional - Chooses which summary measure to be displayed on edges. Defaults to "count". Options: ["count", "none"]
+        :type edge_info: str
 
         :type edge_info: str
         :return: A graphviz Dot representation of the graph.
@@ -323,8 +323,7 @@ class EventTree(nx.MultiDiGraph):
 
         :type filename: str
 
-        :param edge_info: Optional - Chooses which summary measure to be displayed on edges.
-            In event trees, the options are "count" or "none".
+        :param edge_info: Optional - Chooses which summary measure to be displayed on edges. Defaults to "count". Options: ["count", "none"]
         :type edge_info: str
 
         :return: The event tree Image object.

--- a/src/cegpy/trees/_staged.py
+++ b/src/cegpy/trees/_staged.py
@@ -779,7 +779,7 @@ class StagedTree(EventTree):
     def dot_graph(self, edge_info: str = "count", staged: bool = True):
         """Returns Dot graph representation of the staged tree.
 
-        :param edge_info: Optional - Chooses which summary measure to be displayed on edges. Defaults to "count". Options: ["count", "prior", "posterior", "probability", "none"]
+        :param edge_info: Optional - Chooses which summary measure to be displayed on edges. Defaults to "count". Options: ["count", "prior", "posterior", "probability", "no_info"]
         :type edge_info: str
 
         :param staged: if True, returns the coloured staged tree,
@@ -817,7 +817,7 @@ class StagedTree(EventTree):
 
         :type filename: str
 
-        :param edge_info: Optional - Chooses which summary measure to be displayed on edges. Defaults to "count". Options: ["count", "prior", "posterior", "probability", "none"]
+        :param edge_info: Optional - Chooses which summary measure to be displayed on edges. Defaults to "count". Options: ["count", "prior", "posterior", "probability", "no_info"]
         :type edge_info: str
 
         :param staged: if True, returns the coloured staged tree,

--- a/src/cegpy/trees/_staged.py
+++ b/src/cegpy/trees/_staged.py
@@ -779,7 +779,7 @@ class StagedTree(EventTree):
     def dot_graph(self, edge_info: str = "count", staged: bool = True):
         """Returns Dot graph representation of the staged tree.
 
-        :param edge_info: Optional - Chooses which summary measure to be displayed on edges. Defaults to "count". Options: ["count", "prior", "posterior", "probability"]
+        :param edge_info: Optional - Chooses which summary measure to be displayed on edges. Defaults to "count". Options: ["count", "prior", "posterior", "probability", "none"]
         :type edge_info: str
 
         :param staged: if True, returns the coloured staged tree,
@@ -817,8 +817,7 @@ class StagedTree(EventTree):
 
         :type filename: str
 
-        :param edge_info: Optional - Chooses which summary measure to be displayed on edges.
-            In event trees, only "count" can be displayed, so this can be omitted.
+        :param edge_info: Optional - Chooses which summary measure to be displayed on edges. Defaults to "count". Options: ["count", "prior", "posterior", "probability", "none"]
         :type edge_info: str
 
         :param staged: if True, returns the coloured staged tree,


### PR DESCRIPTION
Added the option to include no edge info when drawing et, st or ceg (so that event description is displayed, but edge counts are not). Tested the change locally and all works well.

Also updated the parameter lists to reflect this change to appear in the documentation (and made the edge_info description uniform over different functions).