### PR TITLE
Add missing sphinx configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,6 +20,10 @@ build:
     # Generate on-the-fly Sphinx configuration from Jupyter Book's _config.yml
       - "jupyter-book config sphinx docs/"
 
+sphinx:
+  # Path to your Sphinx configuration file.
+  configuration: docs/_config.yml
+
 formats:
   - pdf
   - epub


### PR DESCRIPTION
## Fix ReadTheDocs 

This PR now includes a fix for the ReadTheDocs missing a configuration issue stated here: https://github.com/g-walley/cegpy/issues/148  

### 🔍 Issue  
ReadTheDocs recently deprecated automatic configuration detection, requiring an explicit `sphinx.configuration` key in `.readthedocs.yaml`.

### ✅ Fix
- **Added** `sphinx.configuration: docs/_config.yml` to `.readthedocs.yaml`.  
- Ensures that ReadTheDocs correctly finds the Sphinx configuration. 

### 🔄 Impact  
With this change, ReadTheDocs builds should not have any issue.  
