### PR TITLE
Fix filename utility path handling

### DIFF
--- a/src/cegpy/utilities/_util.py
+++ b/src/cegpy/utilities/_util.py
@@ -90,13 +90,18 @@ def generate_colour_run(number, starts, ends) -> list:
 
 
 def generate_filename_and_mkdir(filename: Union[str, Path]) -> Tuple[Path, str]:
-    """Creates a filename."""
-    if filename is not Path:
+    """Create a filename ensuring the directory exists.
+
+    If *filename* has no suffix a ``.png`` suffix is appended and the
+    corresponding filetype returned.
+    """
+
+    if not isinstance(filename, Path):
         filename = Path(filename)
 
-    filetype = filename.suffix.strip(".")
-    if filename.suffix == filetype:
-        filename.joinpath(".png")
+    filetype = filename.suffix.lstrip(".")
+    if not filetype:
+        filename = filename.with_suffix(".png")
         filetype = "png"
 
     filename.parent.mkdir(parents=True, exist_ok=True)

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -1,10 +1,13 @@
 """Tests cegpy.utilities"""
 from collections import defaultdict
+from tempfile import TemporaryDirectory
+from pathlib import Path
 import unittest
 from cegpy.utilities import (
     check_list_contains_strings,
     check_tuple_contains_strings,
     create_sampling_zeros,
+    generate_filename_and_mkdir,
 )
 
 
@@ -55,3 +58,18 @@ class TestCegUtil(unittest.TestCase):
         self.assertFalse(check_tuple_contains_strings(("string thing")))
         self.assertTrue(check_tuple_contains_strings(("string one", "string two")))
         self.assertFalse(check_tuple_contains_strings((1, "2")))
+
+    def test_generate_filename_and_mkdir(self) -> None:
+        """Ensure filenames are normalised and directories created."""
+        with TemporaryDirectory() as tmpdir:
+            path_no_ext = Path(tmpdir) / "out" / "fig"
+            filename, filetype = generate_filename_and_mkdir(str(path_no_ext))
+            self.assertTrue(filename.parent.exists())  # directory exists
+            self.assertEqual(filename.suffix, ".png")
+            self.assertEqual(filetype, "png")
+
+            path_with_ext = Path(tmpdir) / "out2" / "fig.svg"
+            filename2, filetype2 = generate_filename_and_mkdir(path_with_ext)
+            self.assertTrue(filename2.parent.exists())
+            self.assertEqual(filename2.suffix, ".svg")
+            self.assertEqual(filetype2, "svg")


### PR DESCRIPTION
## Summary
- ensure `generate_filename_and_mkdir` adds a default `.png` suffix when missing and always creates parent directories
- test `generate_filename_and_mkdir` with and without extensions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897a11f8d3c832ab0edc6bf5cae7778